### PR TITLE
Annotate type

### DIFF
--- a/lib/Exar/Autoloader.php
+++ b/lib/Exar/Autoloader.php
@@ -16,7 +16,7 @@ class Autoloader {
     /**
      * Registers this autoloader on the autoloader queue.
      *
-     * @param $cacheDir the path to cache directory
+     * @param string $cacheDir the path to cache directory
      * @param array $namespaces array with nmespaces to be loaded with this autoloader
      * @param bool $prepend if true, this autoloader will be prepended on the autoload queue, otherwise it is appended
      */


### PR DESCRIPTION
This just adds the type annotation of $cacheDir to the Exar\Autoloader::register() method.
